### PR TITLE
feat: Support passing in xml as a string

### DIFF
--- a/index.php
+++ b/index.php
@@ -12,8 +12,14 @@ header("Content-Type: application/json");
 
 // Get XML source through the 'xml' parameter
 if (!empty($_GET['xml']) && isset($_GET['xml'])) {
-    $xml = simplexml_load_file($_GET['xml']);
-    $json = xmlToArray($xml);
+    // If passed in xml is not a filename
+    if (strpos($_GET["xml"], ".xml") === FALSE) {
+        $xml = simplexml_load_string($_GET['xml']);
+        $json = xmlToArray($xml);
+    } else { // when a file
+        $xml = simplexml_load_file($_GET['xml']);
+        $json = xmlToArray($xml);
+    }
 } else {
     $json = [
         "errors" => [

--- a/index.php
+++ b/index.php
@@ -7,17 +7,23 @@
  * @version 1.1.0
  */
 
+// tests:
+// ensure a get passing innn the file https://api.factmaven.com/xml-to-json/qa?xml=https://medium.com/feed/@ethanosullivan works
+// same as above but add the .xml extension
+// ensure a get passinng in small xmls tirng works
+// same as above but large xml string
+
 // Lets the browser and tools such as Postman know it's JSON
 header("Content-Type: application/json");
 
 // Get XML source through the 'xml' parameter
 if (!empty($_GET['xml']) && isset($_GET['xml'])) {
-    // If passed in xml is not a filename
-    if (strpos($_GET["xml"], ".xml") === FALSE) {
-        $xml = simplexml_load_string($_GET['xml']);
-        $json = xmlToArray($xml);
-    } else { // when a file
+    if (strpos($_GET['xml'], "https://") === 0) { // is a file
+        $path = $_GET['xml'];
         $xml = simplexml_load_file($_GET['xml']);
+        $json = xmlToArray($xml);
+    } else { // Assume it's an xml string
+        $xml = simplexml_load_string($_GET['xml']);
         $json = xmlToArray($xml);
     }
 } else {

--- a/index.php
+++ b/index.php
@@ -14,31 +14,12 @@ header("Content-Type: application/json");
 if (!empty($_GET['xml']) && isset($_GET['xml'])) {
     $xmlQueryString = $_GET['xml'];
 
-    // If query is a file location over http, ensure it's https
-    $curl = curl_init($xmlQueryString);
-    curl_setopt($curl, CURLOPT_NOBODY, true);
-    curl_exec($curl);
-    $curlStatusCode = curl_getinfo($curl, CURLINFO_HTTP_CODE); // 0 for when a file location on users FS
-    curl_close($curl);
-    if ($curlStatusCode === 200 || $curlStatusCode === 301) {
-        if (strpos($xmlQueryString, "http://") === 0) {
-            $json = constructErrorResponse("400", "http Protocol Not Allowed", "The http protocol is not allowed. Please use https.");
-            echo json_encode($json);
-            return;
-        }
-    }
-
-    // For files over https protocol
-    if (strpos($xmlQueryString, "https://") === 0) {
-        $path = $xmlQueryString;
-        $xml = simplexml_load_file($path);
-        $json = xmlToArray($xml);
-        echo json_encode($json);
-        return;
-    }
-
-    // For files on the users FS
-    if (file_exists($xmlQueryString)) {
+    // For files over http protocol
+    if (
+        strpos($xmlQueryString, "http://") === 0
+        ||
+        strpos($xmlQueryString, "https://") === 0
+    ) {
         $path = $xmlQueryString;
         $xml = simplexml_load_file($path);
         $json = xmlToArray($xml);
@@ -47,7 +28,7 @@ if (!empty($_GET['xml']) && isset($_GET['xml'])) {
     }
 
     // Assume it's an xml string
-    // TODO :: Still doesn't handle a large batch of XML. See https://medium.com/feed/@ethanosullivan for example xml
+    // FIXME :: Doesn't handle large batches of XML when PASTED into the URL. Is this a real problem?
     $xml = simplexml_load_string($xmlQueryString);
     $json = xmlToArray($xml);
     echo json_encode($json);


### PR DESCRIPTION
Adds support for passing in xml strings.

example: `GET https://api.whatever?xml=<fortune><name>edward</name></fortune>`.

Tested locally, but of course i assume you'd test it yourself, but here is my request: 
![image](https://user-images.githubusercontent.com/47337480/96755993-5200b900-13cb-11eb-9da3-a36fa9686c6a.png)
